### PR TITLE
correct remoteStorage and BrowserID author info

### DIFF
--- a/index.html
+++ b/index.html
@@ -520,6 +520,13 @@
                   </div>
                 </div>
               </div>
+              <div class="control-group">
+                <div class="controls">
+                  <div class="input-prepend">
+                    <span class="add-on"><i class="icon-remote-storage"></i></span><input class="span2" id="prependedInput" size="16" type="text" placeholder="your remoteStorage address" />
+                  </div>
+                </div>
+              </div>
             </form>
             <ul>
               <li class="icon-info-card">Login with your Info-Card</li>


### PR DESCRIPTION
The BrowserID logo is by Mozilla, not by Github. The remoteStorage logo is made by me but should refer to Unhosted as umbrella of that effort.

Also thank you for adding the logo!
