### PR TITLE
Update Composer package as a "component"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "pfefferle/openwebicons",
 	"description": "OpenWeb Icons",
+	"type": "component",
 	"keywords": [
 		"openweb",
 		"icons",


### PR DESCRIPTION
Using "component" as the Composer type will allow Composer to act on it as a `component` package for front-end development use.