### PR TITLE
Add speak:none to css

### DIFF
--- a/css/openwebicons.css
+++ b/css/openwebicons.css
@@ -14,6 +14,7 @@
   display: inline-block;
   text-decoration: inherit;
   vertical-align: center;
+  speak: none;
   font-smoothing: antialiased;
   -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Add speak:none to all icons to prevent them from being read on screen readers and such.